### PR TITLE
Show undelete link for comments in subreddits that collapse removed comments

### DIFF
--- a/uneddit.js
+++ b/uneddit.js
@@ -41,6 +41,7 @@ function unedditError(formId, display, message, deleted)
 	var form = $("#"+formId);
 	form.find(".md").text(display + message);
 	removeLink(formId, getContentIdFromFormId(formId), deleted, "");
+	form.css("display", "block");
     } else {
 	toggleEdit(formId, getContentIdFromFormId(formId), display + message);
     }
@@ -113,7 +114,13 @@ function createLinks(target)
 		    form.attr("id"), deleted
 		);
 	    });
-	    $(this).append($("<li></li>").append(a));
+	    if (form.css("display") == "none") {
+	        var tagline = $("p.tagline", $(this).parent());
+	        tagline.css("display", "inline");
+	        tagline.after(" ", a);
+	    } else {
+	        $(this).append($("<li></li>").append(a));
+	    }
 	}
     });
 }


### PR DESCRIPTION
Hey,

Some subreddits like /r/askscience use the subreddit stylesheets to collapse removed comments to one line, which hides the undelete link. This change makes the undelete links visible again for removed comments in these subreddits.
